### PR TITLE
directory_extra_parameters and extra_parameters

### DIFF
--- a/templates/vhosts.conf.j2
+++ b/templates/vhosts.conf.j2
@@ -15,13 +15,13 @@ DirectoryIndex index.php index.html
     Order allow,deny
     Allow from all
   {% if vhost.directory_extra_parameters is defined %}
-  {% for param_name, param_value in vhost.directory_extra_parameters|reverse %}
+  {% for param_name, param_value in vhost.directory_extra_parameters.items()|reverse %}
     {{ param_name }} {{ param_value }}
   {% endfor %}
   {% endif %}
   </Directory>
 {% if vhost.extra_parameters is defined %}
-{% for param_name, param_value in vhost.extra_parameters|reverse %}
+{% for param_name, param_value in vhost.extra_parameters.items()|reverse %}
   {{ param_name }} {{ param_value }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
added directory_extra_parameters that would allow to define parameters inside the Directory block
fixed extra_parameters (it was simply outputting the dictionary in one line)
reversing the dictionaries, as to keep the same order as they are defined
