### PR TITLE
Updates Debian APT cache.

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,8 @@
   apt: >
     name={{ item }}
     state=installed
+    update_cache=yes
+    cache_valid_time=3600
   with_items: apache_packages
 
 - name: Configure Apache (Debian).


### PR DESCRIPTION
Executes `apt-get update` if needed, considers 1h of valid cache time.
